### PR TITLE
accesses hhs api directly, adds package-lock, returns data in new structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # npi-js
-========
 
 National Provider Identifier (NPI) Lookup and Extraction
 
 This library provides the following functionality:
 
-* ```find.js``` connects to BloomAPI and looks up provider information in the National Plan and Provider Enumeration System (NPPES)
+* ```find.js``` looks up provider information in the National Plan and Provider Enumeration System (NPPES)
 * ```process.js``` parses out providers from multiple sections of a blue-button record
 
 

--- a/lib/find.js
+++ b/lib/find.js
@@ -1,11 +1,17 @@
-var bloomjs = require('bloom-js');
 var async = require('async');
+var request = require('request');
 
-var options = {
-    url: 'http://www.bloomapi.com/api'
-};
+var npiBaseUrl = 'https://npiregistry.cms.hhs.gov/api/resultsDemo2/';
 
-var bloomClient = new bloomjs.Client(options);
+function hhsNpiQuery(query, callback) {
+    request.get(npiBaseUrl, {
+        json: true,
+        qs: query
+    }, function (err, response, body) {
+        if (err) return callback(err);
+        return callback(null, body.results);
+    });
+}
 
 function buildSearchArray(perfObj, callback) {
     var searchArr = [];
@@ -17,110 +23,58 @@ function buildSearchArray(perfObj, callback) {
                         if (perfObj.name[0].first != null) {
                             if (perfObj.address[0].state) {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first,
+                                    'postal_code': perfObj.address[0].zip,
+                                    'state': perfObj.address[0].state
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first,
+                                    'postal_code': perfObj.address[0].zip
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first,
+                                    'state': perfObj.address[0].state
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first
                                 });
                                 cb();
                             } else {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first,
+                                    'postal_code': perfObj.address[0].zip
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first
                                 });
                                 cb();
                             }
                         } else {
                             if (perfObj.address[0].state) {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'postal_code': perfObj.address[0].zip,
+                                    'state': perfObj.address[0].state
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'postal_code': perfObj.address[0].zip
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'state': perfObj.address[0].state
                                 });
                                 cb();
                             } else {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'practice_address.zip': {
-                                        'eq': perfObj.address[0].zip
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'postal_code': perfObj.address[0].zip
                                 });
                                 cb();
                             }
@@ -129,45 +83,27 @@ function buildSearchArray(perfObj, callback) {
                         if (perfObj.name[0].first != null) {
                             if (perfObj.address[0].state) {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first,
+                                    'state': perfObj.address[0].state
                                 });
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first
                                 });
                                 cb();
                             } else {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'first_name': {
-                                        'eq': perfObj.name[0].first
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'first_name': perfObj.name[0].first
                                 });
                                 cb();
                             }
                         } else {
                             if (perfObj.address[0].state) {
                                 searchArr.push({
-                                    'last_name': {
-                                        'eq': perfObj.name[0].last
-                                    },
-                                    'practice_address.state': {
-                                        'eq': perfObj.address[0].state
-                                    }
+                                    'last_name': perfObj.name[0].last,
+                                    'state': perfObj.address[0].state
                                 });
                                 cb();
                             } else {
@@ -178,12 +114,8 @@ function buildSearchArray(perfObj, callback) {
                 } else {
                     if (perfObj.name[0].first != null) {
                         searchArr.push({
-                            'last_name': {
-                                'eq': perfObj.name[0].last
-                            },
-                            'first_name': {
-                                'eq': perfObj.name[0].first
-                            }
+                            'last_name': perfObj.name[0].last,
+                            'first_name': perfObj.name[0].first
                         });
                         cb();
                     } else {
@@ -197,7 +129,6 @@ function buildSearchArray(perfObj, callback) {
             cb();
         }
     }, function(cb) {
-        console.log("searchArr: " + JSON.stringify(searchArr));
         cb();
     }], function(err, results) {
         callback(searchArr);
@@ -209,17 +140,15 @@ function getNPI(perfObj, callback) {
 
     //add in a check to see if they already have an NPI
     var check = true;
-    var bloomRes = [];
+    var res = [];
     buildSearchArray(perfObj, function(searchArr) {
         async.eachSeries(searchArr, function(searchObj, cb) {
             if (check) {
-                console.log("search: " + JSON.stringify(searchObj, null, 4));
-                bloomClient.search('usgov.hhs.npi', searchObj, function(error, response) {
-                    if (error) return console.log(error.stack);
-                    console.log("response: " + JSON.stringify(response, null, 4));
+                hhsNpiQuery(searchObj, function(error, response) {
+                    if (error) return console.log(error);
                     if (response.length > 0) {
                         check = false;
-                        bloomRes = response;
+                        res = response;
                     }
                     cb();
                 });
@@ -227,8 +156,8 @@ function getNPI(perfObj, callback) {
                 cb();
             }
         }, function(err) {
-            if (bloomRes.length > 0) {
-                callback(null, bloomRes);
+            if (res.length > 0) {
+                callback(null, res);
             } else {
                 callback("no matches found", perfObj);
             }
@@ -244,20 +173,15 @@ function getPagedNPI(perfObj, limit, offset, callback) {
 
     //add in a check to see if they already have an NPI
     var check = true;
-    var bloomRes = [];
+    var res = [];
     buildSearchArray(perfObj, function(searchArr) {
         async.eachSeries(searchArr, function(searchObj, cb) {
             if (check) {
-                console.log("search: " + JSON.stringify(searchObj, null, 4));
-                bloomClient.search('usgov.hhs.npi', searchObj, {
-                    limit: limit,
-                    offset: offset
-                }, function(error, response) {
-                    if (error) return console.log(error.stack);
-                    console.log("response: " + JSON.stringify(response, null, 4));
+                hhsNpiQuery(Object.assign({}, searchObj, { limit, offset }), function(error, response) {
+                    if (error) return console.log(error);
                     if (response.length > 0) {
                         check = false;
-                        bloomRes = response;
+                        res = response;
                     }
                     cb();
                 });
@@ -265,8 +189,8 @@ function getPagedNPI(perfObj, limit, offset, callback) {
                 cb();
             }
         }, function(err) {
-            if (bloomRes.length > 0) {
-                callback(null, bloomRes);
+            if (res.length > 0) {
+                callback(null, res);
             } else {
                 callback("no matches found", perfObj);
             }
@@ -275,64 +199,9 @@ function getPagedNPI(perfObj, limit, offset, callback) {
 }
 
 function getData(npi, callback) {
-    bloomClient.search('usgov.hhs.npi', {
-            npi: npi.toString()
-        }, {
-            limit: 1
-        }, function (err, response) {
-            if (err) return callback(err);
-            callback(null, response);
-        });
+  return hhsNpiQuery({ number: npi }, callback);
 }
 
 module.exports.getNPI = getNPI;
 module.exports.getPagedNPI = getPagedNPI;
 module.exports.getData = getData;
-
-/*
-bloomClient.search('usgov.hhs.npi', {
-'last_name':{
-    'eq':'DENNIS'
-},
-'first_name':{
-    'eq':'HANK'
-},
-'practice_address.zip':{
-    'eq':'44718'
-}
-}, {
-'offset': 0,
-'limit': 10
-}, function(error, response) {
-if (error) return console.log(error.stack);
-console.dir(response);
-});
-
-var testObj = {
-last_name:'DENNIS',
-first_name:'LAURIE'
-}
-
-var searchObj = {};
-
-for (var prop in testObj) {
-searchObj[prop] = {'eq':testObj[prop]};
-}
-
-bloomClient.search('usgov.hhs.npi', searchObj, {
-'offset': 0,
-'limit': 10
-}, function(error, response) {
-if (error) return console.log(error.stack);
-console.dir(response);
-});
-
-bloomClient.search('nucc.hcpt',{
-'code': {
-    'eq':'207RG0100X'
-}
-},function(error,response){
-if (error) return console.log(error.stack);
-console.dir(response);
-});
-*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,340 @@
+{
+  "name": "npi-js",
+  "version": "0.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bloom-js": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/bloom-js/-/bloom-js-0.0.5.tgz",
+      "integrity": "sha1-4J/H9SVOy9Xp2iX03QRZS/2dXII="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "uuid": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "npi-js",
-  "version": "0.1.1",
-  "description": "## find.js",
+  "version": "0.2.0",
+  "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -21,8 +21,8 @@
     "url": "https://github.com/amida-tech/npi-js/issues"
   },
   "dependencies": {
-    "bloom-js": "^0.0.5",
-    "async": "~0.9.0"
+    "async": "~0.9.0",
+    "request": "^2.87.0"
   },
   "devDependencies": {}
 }

--- a/test.js
+++ b/test.js
@@ -1,32 +1,30 @@
 var npi = require('./index');
 
 var testObj = {
-	'name':[
-		{
-			'last':'DENNIS',
-			'first':'HARRY'
-		}
-	],
-	'address':[
-		{
-			'zip':'940406203'
-		}
-	]
+  'name':[
+    {
+      'last':'DENNIS',
+      'first':'HARRY'
+    }
+  ],
+  'address':[
+    {
+      'zip':'940406203'
+    }
+  ]
 };
 
-npi.find.getNPI(testObj,function(err,perfObj,results) {
-	if (err) {
-		console.log(err);
-	} else {
-		console.log("Here" + JSON.stringify(results,null,4));
-
-
-		npi.find.getData(1073624029, function(err, results) {
-			if (err) {
-				console.log(err);
-			} else {
-				console.log(results);
-			}
-		});
-	}
+npi.find.getNPI(testObj,function(err, results) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log(JSON.stringify(results, null, 4));
+  }
+  npi.find.getData(1073624029, function(err, results) {
+    if (err) {
+      console.log(err);
+    } else {
+      console.log(JSON.stringify(results, null, 4));
+    }
+  });
 });


### PR DESCRIPTION
This bumps the minor version. It breaks the previous api because the structure of the return values has changed significantly. This is necessary because bloomapi has shutdown and we now have to fetch npi information directly from the hhs api, which returns the same info in a different structure.

I made as little changes as I could while changing the source of the data.

I also added a package-lock.json

This repo doesn't have robust testing, but for a really simple functionality test run `node test.js`